### PR TITLE
Add dependencies necessary for sitl_gazebo to compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,10 @@ ros-melodic-libmavconn \
 ros-melodic-mavros \
 ros-melodic-mavros-msgs \
 ros-melodic-apriltag \
-ros-melodic-apriltag-ros
+ros-melodic-apriltag-ros \
+libgstreamer-plugins-base1.0-dev \
+python3-numpy \
+python3-jinja2
 ```
 
 ## Setup and Build

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ ros-melodic-apriltag \
 ros-melodic-apriltag-ros \
 libgstreamer-plugins-base1.0-dev \
 python3-numpy \
-python3-jinja2
+python3-jinja2 \
+python-pexpect
 ```
 
 ## Setup and Build


### PR DESCRIPTION
Tried building this from scratch on a fresh Ubuntu 18.04 VM and found some missing dependencies. Updates the README with what I found to be missing.